### PR TITLE
default filter to get all nodes

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -421,7 +421,7 @@ class DefaultConfig {
             category: "default",
             tag: "infrastructure",
             callback: () => {
-                var gremlin = "G.V().Has(" + "'Type',Regex('host|cluster|node|namespace')" + ").descendants().SubGraph()"            
+                var gremlin = ""            
                 window.App.setGremlinFilter(gremlin)
             }
         }


### PR DESCRIPTION
Back to regular default filter - with this filter we missed k8s containers and probably other objects 